### PR TITLE
[FIX/#119] 회원가입 및 로그인 4차 QA

### DIFF
--- a/app/src/main/java/com/example/assu_fe_app/data/dto/auth/AdminSignUpRequestDto.kt
+++ b/app/src/main/java/com/example/assu_fe_app/data/dto/auth/AdminSignUpRequestDto.kt
@@ -1,38 +1,53 @@
 package com.example.assu_fe_app.data.dto.auth
 
-import com.squareup.moshi.JsonClass
+import com.google.gson.annotations.SerializedName
 
-@JsonClass(generateAdapter = true)
 data class AdminSignUpRequestDto(
+    @SerializedName("phoneNumber")
     val phoneNumber: String,
+    @SerializedName("marketingAgree")
     val marketingAgree: Boolean,
+    @SerializedName("locationAgree")
     val locationAgree: Boolean,
+    @SerializedName("commonAuth")
     val commonAuth: CommonAuthDto,
+    @SerializedName("commonInfo")
     val commonInfo: CommonInfoDto
 )
 
-@JsonClass(generateAdapter = true)
 data class CommonAuthDto(
+    @SerializedName("email")
     val email: String,
+    @SerializedName("password")
     val password: String,
-    val department: String,
-    val major: String,
+    @SerializedName("department")
+    val department: String?,
+    @SerializedName("major")
+    val major: String?,
+    @SerializedName("university")
     val university: String
 )
 
-@JsonClass(generateAdapter = true)
 data class CommonInfoDto(
+    @SerializedName("name")
     val name: String,
+    @SerializedName("detailAddress")
     val detailAddress: String,
+    @SerializedName("selectedPlace")
     val selectedPlace: SelectedPlaceDto
 )
 
-@JsonClass(generateAdapter = true)
 data class SelectedPlaceDto(
+    @SerializedName("placeId")
     val placeId: String,
+    @SerializedName("name")
     val name: String,
+    @SerializedName("address")
     val address: String,
+    @SerializedName("roadAddress")
     val roadAddress: String,
+    @SerializedName("latitude")
     val latitude: Double,
+    @SerializedName("longitude")
     val longitude: Double
 )

--- a/app/src/main/java/com/example/assu_fe_app/data/dto/auth/PartnerSignUpRequestDto.kt
+++ b/app/src/main/java/com/example/assu_fe_app/data/dto/auth/PartnerSignUpRequestDto.kt
@@ -1,18 +1,23 @@
 package com.example.assu_fe_app.data.dto.auth
 
-import com.squareup.moshi.JsonClass
+import com.google.gson.annotations.SerializedName
 
-@JsonClass(generateAdapter = true)
 data class PartnerSignUpRequestDto(
+    @SerializedName("phoneNumber")
     val phoneNumber: String,
+    @SerializedName("marketingAgree")
     val marketingAgree: Boolean,
+    @SerializedName("locationAgree")
     val locationAgree: Boolean,
+    @SerializedName("commonAuth")
     val commonAuth: PartnerCommonAuthDto,
+    @SerializedName("commonInfo")
     val commonInfo: CommonInfoDto
 )
 
-@JsonClass(generateAdapter = true)
 data class PartnerCommonAuthDto(
+    @SerializedName("email")
     val email: String,
+    @SerializedName("password")
     val password: String
 )

--- a/app/src/main/java/com/example/assu_fe_app/data/dto/auth/StudentTokenSignUpRequestDto.kt
+++ b/app/src/main/java/com/example/assu_fe_app/data/dto/auth/StudentTokenSignUpRequestDto.kt
@@ -1,18 +1,23 @@
 package com.example.assu_fe_app.data.dto.auth
 
-import com.squareup.moshi.JsonClass
+import com.google.gson.annotations.SerializedName
 
-@JsonClass(generateAdapter = true)
 data class StudentTokenSignUpRequestDto(
+    @SerializedName("phoneNumber")
     val phoneNumber: String,
+    @SerializedName("marketingAgree")
     val marketingAgree: Boolean,
+    @SerializedName("locationAgree")
     val locationAgree: Boolean,
+    @SerializedName("studentTokenAuth")
     val studentTokenAuth: StudentTokenAuthPayloadDto
 )
 
-@JsonClass(generateAdapter = true)
 data class StudentTokenAuthPayloadDto(
+    @SerializedName("sToken")
     val sToken: String,
+    @SerializedName("sIdno")
     val sIdno: String,
+    @SerializedName("university")
     val university: String = "SSU"
 )

--- a/app/src/main/java/com/example/assu_fe_app/data/repositoryImpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/assu_fe_app/data/repositoryImpl/auth/AuthRepositoryImpl.kt
@@ -1,25 +1,26 @@
 package com.example.assu_fe_app.data.repositoryImpl
 
+import android.util.Log
+import com.example.assu_fe_app.data.dto.auth.AdminSignUpRequestDto
 import com.example.assu_fe_app.data.dto.auth.CommonLoginRequestDto
+import com.example.assu_fe_app.data.dto.auth.EmailVerificationRequestDto
+import com.example.assu_fe_app.data.dto.auth.PartnerSignUpRequestDto
 import com.example.assu_fe_app.data.dto.auth.PhoneVerificationSendRequestDto
 import com.example.assu_fe_app.data.dto.auth.PhoneVerificationVerifyRequestDto
 import com.example.assu_fe_app.data.dto.auth.StudentLoginRequestDto
-import com.example.assu_fe_app.data.dto.auth.AdminSignUpRequestDto
-import com.example.assu_fe_app.data.dto.auth.PartnerSignUpRequestDto
 import com.example.assu_fe_app.data.dto.auth.StudentTokenSignUpRequestDto
 import com.example.assu_fe_app.data.dto.auth.StudentTokenVerifyRequestDto
 import com.example.assu_fe_app.data.dto.auth.StudentTokenVerifyResponseDto
-import com.example.assu_fe_app.data.dto.auth.EmailVerificationRequestDto
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.MultipartBody
-import okhttp3.RequestBody.Companion.toRequestBody
+import com.example.assu_fe_app.data.repository.auth.AuthRepository
 import com.example.assu_fe_app.data.service.AuthService
 import com.example.assu_fe_app.data.service.NoAuthService
 import com.example.assu_fe_app.domain.model.auth.LoginModel
-import com.example.assu_fe_app.data.repository.auth.AuthRepository
 import com.example.assu_fe_app.util.RetrofitResult
 import com.example.assu_fe_app.util.apiHandler
 import com.example.assu_fe_app.util.apiHandlerForUnit
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
@@ -86,6 +87,14 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun adminSignUp(request: AdminSignUpRequestDto, signImage: MultipartBody.Part): RetrofitResult<LoginModel> {
         // JSON을 RequestBody로 변환
         val requestJson = com.google.gson.Gson().toJson(request)
+        
+        // 실제 서버로 전송되는 JSON 로그 출력
+        Log.d("AuthRepositoryImpl", "=== 관리자 회원가입 서버 전송 JSON ===")
+        Log.d("AuthRepositoryImpl", "📤 Request JSON:")
+        Log.d("AuthRepositoryImpl", requestJson)
+        Log.d("AuthRepositoryImpl", "📏 JSON 길이: ${requestJson.length}")
+        Log.d("AuthRepositoryImpl", "==========================================")
+        
         val requestBody = requestJson.toRequestBody("application/json".toMediaTypeOrNull())
         val requestPart = MultipartBody.Part.createFormData("request", null, requestBody)
 

--- a/app/src/main/java/com/example/assu_fe_app/domain/model/auth/SignUpData.kt
+++ b/app/src/main/java/com/example/assu_fe_app/domain/model/auth/SignUpData.kt
@@ -12,8 +12,6 @@ data class SignUpData(
     val sIdno: String? = null,
     val marketingAgree: Boolean = false,
     val locationAgree: Boolean = false,
-    val privacyAgree: Boolean = false,
-    val termsAgree: Boolean = false,
     // 관리자 회원가입 관련 필드들
     val email: String? = null,
     val password: String? = null,

--- a/app/src/main/java/com/example/assu_fe_app/presentation/admin/signup/AdminSignUpSealFragment.kt
+++ b/app/src/main/java/com/example/assu_fe_app/presentation/admin/signup/AdminSignUpSealFragment.kt
@@ -106,13 +106,13 @@ class AdminSignUpSealFragment :
 
         // 개별 약관 체크박스 리스너 설정
         binding.cbPrivacyAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용, 서버 미전송)
+            signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
             updateAllAgreeState()
             updateButtonState()
         }
 
         binding.cbMarketingAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
             updateAllAgreeState()
             updateButtonState()
         }
@@ -130,8 +130,8 @@ class AdminSignUpSealFragment :
         binding.cbMarketingAgree.isChecked = isChecked
 
         // ViewModel에 상태 저장
-        signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용)
-        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+        signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
+        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
 
         // 리스너 재설정
         setupCheckboxListeners()

--- a/app/src/main/java/com/example/assu_fe_app/presentation/common/signup/SignUpCompleteFragment.kt
+++ b/app/src/main/java/com/example/assu_fe_app/presentation/common/signup/SignUpCompleteFragment.kt
@@ -21,18 +21,7 @@ class SignUpCompleteFragment : BaseFragment<FragmentSignUpCompleteBinding>(R.lay
     private val signUpViewModel: SignUpViewModel by activityViewModels()
 
     override fun initObserver() {
-        // 회원가입 결과 관찰
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                signUpViewModel.signUpResult.collect { result ->
-                    result?.let {
-                        // 회원가입 성공 시 사용자 이름 표시
-                        val welcomeText = getString(R.string.signup_welcome_format, it.username)
-                        binding.tvSignupDoneUsername.text = welcomeText
-                    }
-                }
-            }
-        }
+        // 회원가입 결과 관찰 (로딩 완료 후 이름 표시를 위해 로딩 상태 관찰에서 처리)
 
         // 로딩 상태 관찰
         viewLifecycleOwner.lifecycleScope.launch {
@@ -55,6 +44,12 @@ class SignUpCompleteFragment : BaseFragment<FragmentSignUpCompleteBinding>(R.lay
                             navigateToLogin()
                         } else if (result != null) {
                             Log.d("SignUpCompleteFragment", "회원가입 성공: $result")
+                            // 로딩 완료 후 사용자 이름 표시
+                            val userName = result.basicInfo?.name ?: result.username
+                            val welcomeText = getString(R.string.signup_welcome_format, userName)
+                            binding.tvSignupDoneUsername.text = welcomeText
+                            
+                            Log.d("SignUpCompleteFragment", "로딩 완료 후 사용자 이름 표시: $userName")
                         }
                         Log.d("SignUpCompleteFragment", "=============================")
                     }

--- a/app/src/main/java/com/example/assu_fe_app/presentation/common/signup/SignUpVerifyFragment.kt
+++ b/app/src/main/java/com/example/assu_fe_app/presentation/common/signup/SignUpVerifyFragment.kt
@@ -49,6 +49,12 @@ class SignUpVerifyFragment :
 
     private var timerStartTime: Long = 0L
     private var timerEndTime: Long = 0L
+    
+    // 토스트 메시지 중복 방지를 위한 플래그
+    private var isShowingToast = false
+    
+    // API 호출 중복 방지를 위한 플래그
+    private var isVerificationInProgress = false
 
     override fun initObserver() {
         viewModel.sendPhoneVerificationState.observe(this) { state ->
@@ -62,8 +68,13 @@ class SignUpVerifyFragment :
                     // 버튼 재활성화
                     binding.tvUserVerifyPhone.isEnabled = true
                     
-                    // ViewModel에서 전달된 메시지 사용
-                    Toast.makeText(requireContext(), state.message ?: "인증번호 발송에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                    // 토스트 메시지 중복 방지
+                    if (!isShowingToast) {
+                        isShowingToast = true
+                        Toast.makeText(requireContext(), state.message ?: "인증번호 발송에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                        // 토스트 표시 후 플래그 초기화
+                        binding.root.postDelayed({ isShowingToast = false }, 3000)
+                    }
                     
                     // 400, 409 에러 시 UI 업데이트 (빨간색 표시)
                     if (state.code == 400 || state.code == 409) {
@@ -74,8 +85,13 @@ class SignUpVerifyFragment :
                     Log.d("SignUpVerifyViewModel", "네트워크 에러: ${state.message}")
                     // 버튼 재활성화
                     binding.tvUserVerifyPhone.isEnabled = true
-                    // 네트워크 에러 메시지 표시
-                    Toast.makeText(requireContext(), state.message ?: "네트워크 연결을 확인해주세요.", Toast.LENGTH_SHORT).show()
+                    // 토스트 메시지 중복 방지
+                    if (!isShowingToast) {
+                        isShowingToast = true
+                        Toast.makeText(requireContext(), state.message ?: "네트워크 연결을 확인해주세요.", Toast.LENGTH_SHORT).show()
+                        // 토스트 표시 후 플래그 초기화
+                        binding.root.postDelayed({ isShowingToast = false }, 3000)
+                    }
                 }
                 is SendPhoneVerificationUiState.Idle -> {
                     // 버튼 활성화
@@ -92,23 +108,36 @@ class SignUpVerifyFragment :
             Log.d("SignUpVerifyFragment", "Verification state changed: $state")
             when (state) {
                 is VerifyPhoneVerificationUiState.Success -> {
+                    isVerificationInProgress = false
                     successVerificationUI()
                 }
                 is VerifyPhoneVerificationUiState.Fail -> {
+                    isVerificationInProgress = false
                     Log.d("SignUpVerifyFragment", "인증번호 검증 실패: code=${state.code}, message=${state.message}")
                     errorVerificationUI()
                     // 버튼 재활성화
                     binding.btnCompleted.isEnabled = true
-                    // 사용자 친화적 메시지 표시 (한 번만)
-                    Toast.makeText(requireContext(), "인증번호가 올바르지 않습니다.", Toast.LENGTH_SHORT).show()
+                    // 토스트 메시지 중복 방지
+                    if (!isShowingToast) {
+                        isShowingToast = true
+                        Toast.makeText(requireContext(), "인증번호가 올바르지 않습니다.", Toast.LENGTH_SHORT).show()
+                        // 토스트 표시 후 플래그 초기화
+                        binding.root.postDelayed({ isShowingToast = false }, 3000)
+                    }
                 }
                 is VerifyPhoneVerificationUiState.Error -> {
+                    isVerificationInProgress = false
                     errorVerificationUI()
                     Log.d("SignUpVerifyViewModel", "네트워크 에러: ${state.message}")
                     // 버튼 재활성화
                     binding.btnCompleted.isEnabled = true
-                    // 네트워크 에러 메시지 표시 (한 번만)
-                    Toast.makeText(requireContext(), "네트워크 연결을 확인해주세요.", Toast.LENGTH_SHORT).show()
+                    // 토스트 메시지 중복 방지
+                    if (!isShowingToast) {
+                        isShowingToast = true
+                        Toast.makeText(requireContext(), "네트워크 연결을 확인해주세요.", Toast.LENGTH_SHORT).show()
+                        // 토스트 표시 후 플래그 초기화
+                        binding.root.postDelayed({ isShowingToast = false }, 3000)
+                    }
                 }
                 is VerifyPhoneVerificationUiState.Idle -> {
                     // 버튼 활성화
@@ -214,25 +243,9 @@ class SignUpVerifyFragment :
                 
                 // 기존 타이머 제거
                 binding.etUserVerifyCode.removeCallbacks(focusClearRunnable)
-                val errorDrawableState = ContextCompat.getDrawable(
-                    requireContext(),
-                    R.drawable.bg_signup_input_bar_error
-                )?.constantState
-
-                val currentBackgroundState = binding.clUserVerifyCode.background.constantState
-
-                if (currentBackgroundState == errorDrawableState) {
-                    binding.clUserVerifyCode.background =
-                        ContextCompat.getDrawable(requireContext(), R.drawable.bg_signup_input_bar_selected)
-
-                    binding.ivUserVerifyCodeCheckIcon.visibility = View.GONE
-
-                    // 오류 문구 대신 타이머 텍스트 복원
-                    binding.tvUserVerifyCode.text = lastTimerText
-                    binding.tvUserVerifyCode.setTextColor(
-                        ContextCompat.getColor(requireContext(), R.color.assu_main)
-                    )
-                }
+                
+                // 텍스트가 변경되면 항상 에러 상태 초기화
+                resetVerificationErrorState()
             }
 
             override fun afterTextChanged(s: Editable?) {
@@ -252,9 +265,9 @@ class SignUpVerifyFragment :
                         checkVerificationCode()
                     }, 500) // 0.5초 후 검증
                 } else {
-                    // 6자리 미만일 때는 아무것도 하지 않음 (API 호출 안함)
-                    Log.d("SignUpVerifyFragment", "Incomplete code - length: ${text.length}, no API call")
-                    // 타이핑 플래그는 유지하여 focus out에서도 API 호출하지 않도록 함
+                    // 6자리 미만일 때는 타이핑 플래그를 false로 설정하여 focus out에서도 API 호출하지 않도록 함
+                    isTyping = false
+                    Log.d("SignUpVerifyFragment", "Incomplete code - length: ${text.length}, no API call, isTyping set to false")
                 }
             }
         })
@@ -352,24 +365,35 @@ class SignUpVerifyFragment :
     }
 
     private fun checkVerificationCode() {
+        // API 호출 중복 방지
+        if (isVerificationInProgress) {
+            Log.d("SignUpVerifyFragment", "⚠️ API 호출 이미 진행 중 - 중복 호출 방지")
+            return
+        }
+        
         val enteredCode = binding.etUserVerifyCode.text.toString().trim()
         val phoneNumber = binding.etUserVerifyPhone.text.toString().trim()
 
         Log.d("SignUpVerifyFragment", "=== checkVerificationCode() called ===")
-        Log.d("SignUpVerifyFragment", "enteredCode: '$enteredCode'")
-        Log.d("SignUpVerifyFragment", "phoneNumber: '$phoneNumber'")
+        Log.d("SignUpVerifyFragment", "🔍 API 전송 데이터:")
+        Log.d("SignUpVerifyFragment", "   📱 전화번호: '$phoneNumber'")
+        Log.d("SignUpVerifyFragment", "   🔢 인증번호: '$enteredCode'")
+        Log.d("SignUpVerifyFragment", "   📏 인증번호 길이: ${enteredCode.length}")
 
         // 키보드 내리기
         val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(binding.etUserVerifyCode.windowToken, 0)
 
         if (enteredCode.isNotEmpty() && phoneNumber.isNotEmpty()) {
-            Log.d("SignUpVerifyFragment", "Calling viewModel.verifyPhoneVerification()")
+            Log.d("SignUpVerifyFragment", "✅ API 호출 조건 만족 - verifyPhoneVerification() 호출")
+            isVerificationInProgress = true
             // 이전 상태 초기화 (중복 토스트 방지)
             viewModel.resetVerificationState()
             viewModel.verifyPhoneVerification(phoneNumber, enteredCode)
         } else {
-            Log.w("SignUpVerifyFragment", "Verification skipped - missing phone or code")
+            Log.w("SignUpVerifyFragment", "❌ API 호출 조건 불만족")
+            Log.w("SignUpVerifyFragment", "   전화번호 비어있음: ${phoneNumber.isEmpty()}")
+            Log.w("SignUpVerifyFragment", "   인증번호 비어있음: ${enteredCode.isEmpty()}")
             Toast.makeText(requireContext(), "인증번호를 입력해주세요", Toast.LENGTH_SHORT).show()
         }
     }
@@ -434,6 +458,29 @@ class SignUpVerifyFragment :
         binding.tvUserVerifyPhone.setTextColor(ContextCompat.getColor(requireContext(), R.color.assu_main))
     }
 
+    private fun resetVerificationErrorState() {
+        // 인증번호 입력 필드의 에러 상태 초기화
+        val errorDrawableState = ContextCompat.getDrawable(
+            requireContext(),
+            R.drawable.bg_signup_input_bar_error
+        )?.constantState
+
+        val currentBackgroundState = binding.clUserVerifyCode.background.constantState
+
+        if (currentBackgroundState == errorDrawableState) {
+            binding.clUserVerifyCode.background =
+                ContextCompat.getDrawable(requireContext(), R.drawable.bg_signup_input_bar_selected)
+
+            binding.ivUserVerifyCodeCheckIcon.visibility = View.GONE
+
+            // 오류 문구 대신 타이머 텍스트 복원
+            binding.tvUserVerifyCode.text = lastTimerText
+            binding.tvUserVerifyCode.setTextColor(
+                ContextCompat.getColor(requireContext(), R.color.assu_main)
+            )
+        }
+    }
+
     private fun resetUI() {
         isVerified = false
         binding.etUserVerifyPhone.isEnabled = true
@@ -462,6 +509,8 @@ class SignUpVerifyFragment :
         countDownTimer?.cancel()
         binding.etUserVerifyCode.removeCallbacks(focusClearRunnable)
         isTyping = false
+        isVerificationInProgress = false
+        isShowingToast = false
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/example/assu_fe_app/presentation/partner/signup/PartnerSignUpLicenseFragment.kt
+++ b/app/src/main/java/com/example/assu_fe_app/presentation/partner/signup/PartnerSignUpLicenseFragment.kt
@@ -104,13 +104,13 @@ class PartnerSignUpLicenseFragment :
 
         // 개별 약관 체크박스 리스너 설정
         binding.cbPrivacyAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용, 서버 미전송)
+            signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
             updateAllAgreeState()
             updateButtonState()
         }
 
         binding.cbMarketingAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
             updateAllAgreeState()
             updateButtonState()
         }
@@ -128,8 +128,8 @@ class PartnerSignUpLicenseFragment :
         binding.cbMarketingAgree.isChecked = isChecked
 
         // ViewModel에 상태 저장
-        signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용)
-        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+        signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
+        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
 
         // 리스너 재설정
         setupCheckboxListeners()

--- a/app/src/main/java/com/example/assu_fe_app/presentation/user/signup/UserSignUpStudentCheckFragment.kt
+++ b/app/src/main/java/com/example/assu_fe_app/presentation/user/signup/UserSignUpStudentCheckFragment.kt
@@ -115,8 +115,8 @@ class UserSignUpStudentCheckFragment :
         binding.cbMarketingAgree.isChecked = isChecked
 
         // ViewModel에 상태 저장
-        signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용)
-        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+        signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
+        signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
 
         // 리스너 재설정
         setupCheckboxListeners()
@@ -148,13 +148,13 @@ class UserSignUpStudentCheckFragment :
 
         // 개별 약관 체크박스 리스너 설정
         binding.cbPrivacyAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setPrivacyAgree(isChecked) // 필수 약관 (UI 검증용, 서버 미전송)
+            signUpViewModel.setLocationAgree(isChecked) // 필수 약관 (개인정보처리방침 + 위치정보 수집동의)
             updateAllAgreeState()
             updateButtonState()
         }
 
         binding.cbMarketingAgree.setOnCheckedChangeListener { _, isChecked ->
-            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (마케팅 + 위치정보 동시 설정)
+            signUpViewModel.setMarketingAgree(isChecked) // 선택 약관 (Email 및 SMS 마케팅 수신 동의)
             updateAllAgreeState()
             updateButtonState()
         }

--- a/app/src/main/java/com/example/assu_fe_app/ui/auth/SignUpVerifyViewModel.kt
+++ b/app/src/main/java/com/example/assu_fe_app/ui/auth/SignUpVerifyViewModel.kt
@@ -82,35 +82,40 @@ class SignUpVerifyViewModel @Inject constructor(
 
     fun verifyPhoneVerification(phoneNumber: String, authNumber: String) {
         Log.d("SignUpVerifyViewModel", "=== verifyPhoneVerification() called ===")
-        Log.d("SignUpVerifyViewModel", "phoneNumber: '$phoneNumber'")
-        Log.d("SignUpVerifyViewModel", "authNumber: '$authNumber'")
+        Log.d("SignUpVerifyViewModel", "🔍 ViewModel에서 API 전송 데이터:")
+        Log.d("SignUpVerifyViewModel", "   📱 전화번호: '$phoneNumber'")
+        Log.d("SignUpVerifyViewModel", "   🔢 인증번호: '$authNumber'")
+        Log.d("SignUpVerifyViewModel", "   📏 인증번호 길이: ${authNumber.length}")
         
         // 이미 로딩 중이면 중복 요청 방지
         if (_verifyPhoneVerificationState.value is VerifyPhoneVerificationUiState.Loading) {
-            Log.d("SignUpVerifyViewModel", "Already loading, skipping request")
+            Log.d("SignUpVerifyViewModel", "⚠️ Already loading, skipping request")
             return
         }
         
         viewModelScope.launch {
-            Log.d("SignUpVerifyViewModel", "Setting loading state")
+            Log.d("SignUpVerifyViewModel", "🔄 Setting loading state")
             _verifyPhoneVerificationState.value = VerifyPhoneVerificationUiState.Loading
             
             val request = PhoneVerificationVerifyRequestDto(
                 phoneNumber = phoneNumber,
                 authNumber = authNumber
             )
-            Log.d("SignUpVerifyViewModel", "Calling authRepository.verifyPhoneVerification()")
+            Log.d("SignUpVerifyViewModel", "📤 API Request DTO 생성:")
+            Log.d("SignUpVerifyViewModel", "   📱 request.phoneNumber: '${request.phoneNumber}'")
+            Log.d("SignUpVerifyViewModel", "   🔢 request.authNumber: '${request.authNumber}'")
+            Log.d("SignUpVerifyViewModel", "🚀 Calling authRepository.verifyPhoneVerification()")
             authRepository.verifyPhoneVerification(request)
                 .onSuccess { 
-                    Log.d("SignUpVerifyViewModel", "Verification success")
+                    Log.d("SignUpVerifyViewModel", "✅ Verification success")
                     _verifyPhoneVerificationState.value = VerifyPhoneVerificationUiState.Success 
                 }
                 .onFail { code -> 
-                    Log.d("SignUpVerifyViewModel", "Verification failed with code: $code")
+                    Log.d("SignUpVerifyViewModel", "❌ Verification failed with code: $code")
                     _verifyPhoneVerificationState.value = VerifyPhoneVerificationUiState.Fail(code, "인증번호 검증 실패") 
                 }
                 .onError { e -> 
-                    Log.d("SignUpVerifyViewModel", "Verification error: ${e.message}")
+                    Log.d("SignUpVerifyViewModel", "💥 Verification error: ${e.message}")
                     _verifyPhoneVerificationState.value = VerifyPhoneVerificationUiState.Error(e.message ?: "Unknown Error") 
                 }
         }

--- a/app/src/main/java/com/example/assu_fe_app/ui/auth/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/assu_fe_app/ui/auth/SignUpViewModel.kt
@@ -107,16 +107,17 @@ class SignUpViewModel @Inject constructor(
         )
     }
 
-    // 필수 약관 동의 설정 (서버에 전송하지 않음, UI 검증용)
-    fun setPrivacyAgree(agree: Boolean) {
-        _signUpData.value = _signUpData.value.copy(privacyAgree = agree)
+    // 필수 동의 설정 (개인정보처리방침 + 위치정보 수집동의)
+    fun setLocationAgree(agree: Boolean) {
+        _signUpData.value = _signUpData.value.copy(
+            locationAgree = agree
+        )
     }
 
-    // 선택 약관 동의 설정 (마케팅 + 위치정보 함께 설정)
+    // 선택 동의 설정 (Email 및 SMS 마케팅 수신 동의)
     fun setMarketingAgree(agree: Boolean) {
         _signUpData.value = _signUpData.value.copy(
-            marketingAgree = agree,
-            locationAgree = agree
+            marketingAgree = agree
         )
     }
 
@@ -355,13 +356,15 @@ class SignUpViewModel @Inject constructor(
             )
 
             // API 호출 직전 전달되는 정보 로그 출력
-            Log.d("SignUpViewModel", "=== 학생 회원가입 API 호출 - 전달되는 정보 ===")
-            Log.d("SignUpViewModel", "Phone Number: ${request.phoneNumber}")
-            Log.d("SignUpViewModel", "Marketing Agree: ${request.marketingAgree}")
-            Log.d("SignUpViewModel", "Location Agree: ${request.locationAgree}")
-            Log.d("SignUpViewModel", "Student Token: ${request.studentTokenAuth.sToken}")
-            Log.d("SignUpViewModel", "Student ID: ${request.studentTokenAuth.sIdno}")
-            Log.d("SignUpViewModel", "University: ${request.studentTokenAuth.university}")
+            // API 요청 데이터 로그 출력
+            Log.d("SignUpViewModel", "=== 학생 회원가입 API 요청 데이터 ===")
+            Log.d("SignUpViewModel", "📱 phoneNumber: '${request.phoneNumber}'")
+            Log.d("SignUpViewModel", "📧 marketingAgree: ${request.marketingAgree}")
+            Log.d("SignUpViewModel", "📍 locationAgree: ${request.locationAgree}")
+            Log.d("SignUpViewModel", "🎓 studentTokenAuth:")
+            Log.d("SignUpViewModel", "   - sToken: '${request.studentTokenAuth.sToken}'")
+            Log.d("SignUpViewModel", "   - sIdno: '${request.studentTokenAuth.sIdno}'")
+            Log.d("SignUpViewModel", "   - university: '${request.studentTokenAuth.university}'")
             Log.d("SignUpViewModel", "==========================================")
 
             when (val result = studentSignUpUseCase(request)) {
@@ -396,13 +399,16 @@ class SignUpViewModel @Inject constructor(
                 }
                 is RetrofitResult.Fail -> {
                     Log.e("SignUpViewModel", "=== 학생 회원가입 API 실패 ===")
-                    Log.e("SignUpViewModel", "Status Code: ${result.statusCode}")
-                    Log.e("SignUpViewModel", "Message: ${result.message}")
+                    Log.e("SignUpViewModel", "❌ Status Code: ${result.statusCode}")
+                    Log.e("SignUpViewModel", "💬 Message: ${result.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.message
                 }
                 is RetrofitResult.Error -> {
                     Log.e("SignUpViewModel", "=== 학생 회원가입 API 에러 ===")
-                    Log.e("SignUpViewModel", "Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "💥 Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "📝 Exception Message: ${result.exception.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.exception.message ?: "네트워크 오류가 발생했습니다."
                 }
             }
@@ -434,8 +440,8 @@ class SignUpViewModel @Inject constructor(
                 commonAuth = CommonAuthDto(
                     email = data.email!!,
                     password = data.password!!,
-                    department = data.department?.takeIf { it.isNotEmpty() } ?: "N/A",
-                    major = data.major?.takeIf { it.isNotEmpty() } ?: "N/A",
+                    department = data.department?.takeIf { it.isNotEmpty() },
+                    major = data.major?.takeIf { it.isNotEmpty() },
                     university = data.university!!
                 ),
                 commonInfo = CommonInfoDto(
@@ -444,6 +450,30 @@ class SignUpViewModel @Inject constructor(
                     selectedPlace = data.selectedPlace!!
                 )
             )
+
+            // API 요청 데이터 로그 출력
+            Log.d("SignUpViewModel", "=== 관리자 회원가입 API 요청 데이터 ===")
+            Log.d("SignUpViewModel", "📱 phoneNumber: '${request.phoneNumber}'")
+            Log.d("SignUpViewModel", "📧 marketingAgree: ${request.marketingAgree}")
+            Log.d("SignUpViewModel", "📍 locationAgree: ${request.locationAgree}")
+            Log.d("SignUpViewModel", "🔐 commonAuth:")
+            Log.d("SignUpViewModel", "   - email: '${request.commonAuth.email}'")
+            Log.d("SignUpViewModel", "   - password: '[HIDDEN]'")
+            Log.d("SignUpViewModel", "   - department: ${request.commonAuth.department ?: "null"}")
+            Log.d("SignUpViewModel", "   - major: ${request.commonAuth.major ?: "null"}")
+            Log.d("SignUpViewModel", "   - university: '${request.commonAuth.university}'")
+            Log.d("SignUpViewModel", "🏢 commonInfo:")
+            Log.d("SignUpViewModel", "   - name: '${request.commonInfo.name}'")
+            Log.d("SignUpViewModel", "   - detailAddress: '${request.commonInfo.detailAddress}'")
+            Log.d("SignUpViewModel", "   - selectedPlace:")
+            Log.d("SignUpViewModel", "     * placeId: '${request.commonInfo.selectedPlace.placeId}'")
+            Log.d("SignUpViewModel", "     * name: '${request.commonInfo.selectedPlace.name}'")
+            Log.d("SignUpViewModel", "     * address: '${request.commonInfo.selectedPlace.address}'")
+            Log.d("SignUpViewModel", "     * roadAddress: '${request.commonInfo.selectedPlace.roadAddress}'")
+            Log.d("SignUpViewModel", "     * latitude: ${request.commonInfo.selectedPlace.latitude}")
+            Log.d("SignUpViewModel", "     * longitude: ${request.commonInfo.selectedPlace.longitude}")
+            Log.d("SignUpViewModel", "📎 signImageFile: ${data.signImageFile?.name ?: "null"}")
+            Log.d("SignUpViewModel", "==========================================")
 
             // 이미지 파일을 MultipartBody.Part로 변환
             val signImageFile = data.signImageFile!!
@@ -518,13 +548,16 @@ class SignUpViewModel @Inject constructor(
                 }
                 is RetrofitResult.Fail -> {
                     Log.e("SignUpViewModel", "=== 관리자 회원가입 API 실패 ===")
-                    Log.e("SignUpViewModel", "Status Code: ${result.statusCode}")
-                    Log.e("SignUpViewModel", "Message: ${result.message}")
+                    Log.e("SignUpViewModel", "❌ Status Code: ${result.statusCode}")
+                    Log.e("SignUpViewModel", "💬 Message: ${result.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.message
                 }
                 is RetrofitResult.Error -> {
                     Log.e("SignUpViewModel", "=== 관리자 회원가입 API 에러 ===")
-                    Log.e("SignUpViewModel", "Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "💥 Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "📝 Exception Message: ${result.exception.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.exception.message ?: "네트워크 오류가 발생했습니다."
                 }
             }
@@ -629,13 +662,16 @@ class SignUpViewModel @Inject constructor(
                 }
                 is RetrofitResult.Fail -> {
                     Log.e("SignUpViewModel", "=== 제휴업체 회원가입 API 실패 ===")
-                    Log.e("SignUpViewModel", "Status Code: ${result.statusCode}")
-                    Log.e("SignUpViewModel", "Message: ${result.message}")
+                    Log.e("SignUpViewModel", "❌ Status Code: ${result.statusCode}")
+                    Log.e("SignUpViewModel", "💬 Message: ${result.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.message
                 }
                 is RetrofitResult.Error -> {
                     Log.e("SignUpViewModel", "=== 제휴업체 회원가입 API 에러 ===")
-                    Log.e("SignUpViewModel", "Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "💥 Exception: ${result.exception}")
+                    Log.e("SignUpViewModel", "📝 Exception Message: ${result.exception.message}")
+                    Log.e("SignUpViewModel", "==========================================")
                     _errorMessage.value = result.exception.message ?: "네트워크 오류가 발생했습니다."
                 }
             }
@@ -648,8 +684,7 @@ class SignUpViewModel @Inject constructor(
         val isValid = !data.phoneNumber.isNullOrEmpty() &&
                 !data.sToken.isNullOrEmpty() &&
                 !data.sIdno.isNullOrEmpty() &&
-                data.privacyAgree &&
-                data.termsAgree &&
+                data.locationAgree &&
                 data.userType == "user"
         
         // 유효성 검사 결과 로그 출력
@@ -657,8 +692,8 @@ class SignUpViewModel @Inject constructor(
         Log.d("SignUpViewModel", "Phone Number: '${data.phoneNumber}' (valid: ${!data.phoneNumber.isNullOrEmpty()})")
         Log.d("SignUpViewModel", "Student Token: '${data.sToken}' (valid: ${!data.sToken.isNullOrEmpty()})")
         Log.d("SignUpViewModel", "Student ID: '${data.sIdno}' (valid: ${!data.sIdno.isNullOrEmpty()})")
-        Log.d("SignUpViewModel", "Privacy Agree: ${data.privacyAgree}")
-        Log.d("SignUpViewModel", "Terms Agree: ${data.termsAgree}")
+        Log.d("SignUpViewModel", "Location Agree: ${data.locationAgree}")
+        Log.d("SignUpViewModel", "Marketing Agree: ${data.marketingAgree}")
         Log.d("SignUpViewModel", "User Type: '${data.userType}' (valid: ${data.userType == "user"})")
         Log.d("SignUpViewModel", "Overall Valid: $isValid")
         Log.d("SignUpViewModel", "=====================================")
@@ -675,8 +710,7 @@ class SignUpViewModel @Inject constructor(
                 !data.detailAddress.isNullOrEmpty() &&
                 data.selectedPlace != null &&
                 data.signImageFile != null &&
-                data.privacyAgree &&
-                data.termsAgree &&
+                data.locationAgree &&
                 data.userType == "admin"
         
         // 유효성 검사 결과 로그 출력
@@ -698,8 +732,8 @@ class SignUpViewModel @Inject constructor(
             Log.d("SignUpViewModel", "  - Longitude: ${data.selectedPlace.longitude}")
         }
         Log.d("SignUpViewModel", "Sign Image File: ${data.signImageFile?.name ?: "null"} (valid: ${data.signImageFile != null})")
-        Log.d("SignUpViewModel", "Privacy Agree: ${data.privacyAgree}")
-        Log.d("SignUpViewModel", "Terms Agree: ${data.termsAgree}")
+        Log.d("SignUpViewModel", "Location Agree: ${data.locationAgree}")
+        Log.d("SignUpViewModel", "Marketing Agree: ${data.marketingAgree}")
         Log.d("SignUpViewModel", "User Type: '${data.userType}' (valid: ${data.userType == "admin"})")
         Log.d("SignUpViewModel", "Overall Valid: $isValid")
         Log.d("SignUpViewModel", "=====================================")
@@ -716,8 +750,7 @@ class SignUpViewModel @Inject constructor(
                 !data.detailAddress.isNullOrEmpty() &&
                 data.selectedPlace != null &&
                 data.licenseImageFile != null &&
-                data.privacyAgree &&
-                data.termsAgree &&
+                data.locationAgree &&
                 data.userType == "partner"
         
         // 유효성 검사 결과 로그 출력
@@ -742,8 +775,8 @@ class SignUpViewModel @Inject constructor(
             Log.d("SignUpViewModel", "  - Longitude: ${data.selectedPlace.longitude}")
         }
         Log.d("SignUpViewModel", "License Image File: ${data.licenseImageFile?.name ?: "null"} (valid: ${data.licenseImageFile != null})")
-        Log.d("SignUpViewModel", "Privacy Agree: ${data.privacyAgree}")
-        Log.d("SignUpViewModel", "Terms Agree: ${data.termsAgree}")
+        Log.d("SignUpViewModel", "Location Agree: ${data.locationAgree}")
+        Log.d("SignUpViewModel", "Marketing Agree: ${data.marketingAgree}")
         Log.d("SignUpViewModel", "User Type: '${data.userType}' (valid: ${data.userType == "partner"})")
         Log.d("SignUpViewModel", "Overall Valid: $isValid")
         Log.d("SignUpViewModel", "=====================================")

--- a/app/src/main/res/layout/fragment_sign_up_complete.xml
+++ b/app/src/main/res/layout/fragment_sign_up_complete.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="26dp"
-            android:text="이호근님\n환영합니다!"
+            android:text=""
             android:textSize="30sp"
             android:textColor="@color/assu_font_main"
             android:gravity="center"

--- a/app/src/main/res/layout/fragment_sign_up_verify.xml
+++ b/app/src/main/res/layout/fragment_sign_up_verify.xml
@@ -116,7 +116,10 @@
                     android:text="인증번호 받기"
                     android:textColor="@color/assu_main"
                     android:textSize="13sp"
-                    android:fontFamily="@font/pretendard_medium"/>
+                    android:fontFamily="@font/pretendard_medium"
+                    android:minHeight="32dp"
+                    android:gravity="center"
+                    android:paddingVertical="6dp"/>
             </LinearLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## #️⃣PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪵반영 브랜치
ex) feat/login -> dev

## 📝작업 내용
- SignUpVerifyFragment(전화번호 검증) 버그 수정:
  - 인증번호 재입력 시 틀린 것으로 인식하는 문제 해결
  - 포커싱 아웃 시 중복 API 호출 방지 로직 추가
  - 토스트 메시지 중복 방지 로직 추가
  - 인증번호 받기 버튼 클릭 범위 확대

- 회원가입 버그 수정:
  - 여러 필드 중 null값이 아닌 ""으로 보내 발생하던 버그였음
  - 불필요한 privacyAgree, termsAgree 필드 제거
  - UI와 데이터 구조 일치화 (개인정보+위치정보 → locationAgree, 마케팅 → marketingAgree)
  - 동의 항목 매핑 정확성 개선

- DTO 라이브러리 통일

- SignUpCompleteFragment 사용자 경험 개선
  - 하드코딩된 사용자 이름 제거

## ✅테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브

모든 사용자 입장에서 회원가입 테스트 완료했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
