### PR TITLE
[FIX/#138] 자동 로그인 기능 fix

### DIFF
--- a/app/src/main/java/com/ssu/assu/data/local/AuthTokenLocalStoreImpl.kt
+++ b/app/src/main/java/com/ssu/assu/data/local/AuthTokenLocalStoreImpl.kt
@@ -228,7 +228,16 @@ class AuthTokenLocalStoreImpl @Inject constructor(
 
     /****************************** 상태 관련 메소드 ******************************/
     override fun isLoggedIn(): Boolean {
-        return prefs.getBoolean(KEY_IS_LOGGED_IN, false) && getAccessToken() != null
+        val isLoggedInFlag = prefs.getBoolean(KEY_IS_LOGGED_IN, false)
+        val accessToken = getAccessToken()
+        val result = isLoggedInFlag && accessToken != null
+        
+        android.util.Log.d("AuthTokenLocalStore", "=== isLoggedIn() 체크 ===")
+        android.util.Log.d("AuthTokenLocalStore", "KEY_IS_LOGGED_IN: $isLoggedInFlag")
+        android.util.Log.d("AuthTokenLocalStore", "Access Token 존재: ${accessToken != null}")
+        android.util.Log.d("AuthTokenLocalStore", "최종 결과: $result")
+        
+        return result
     }
 
     override fun isAccessTokenExpired(): Boolean {

--- a/app/src/main/java/com/ssu/assu/data/remote/AuthAuthenticator.kt
+++ b/app/src/main/java/com/ssu/assu/data/remote/AuthAuthenticator.kt
@@ -1,0 +1,153 @@
+package com.ssu.assu.data.remote
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.ssu.assu.MyApplication
+import com.ssu.assu.data.local.AccessTokenProvider
+import com.ssu.assu.data.local.AuthTokenLocalStore
+import com.ssu.assu.data.repository.TokenRefreshRepository
+import com.ssu.assu.presentation.common.login.LoginActivity
+import com.ssu.assu.util.RetrofitResult
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+/**
+ * OkHttp3 Authenticator 구현
+ * 401 http error code를 받았을 때 호출되는 클래스
+ * Access Token 만료 시 Refresh Token으로 교체 후 API 재요청
+ */
+class AuthAuthenticator @Inject constructor(
+    private val accessTokenProvider: AccessTokenProvider,
+    private val tokenRefreshRepository: TokenRefreshRepository,
+    private val authTokenLocalStore: AuthTokenLocalStore
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        Log.d("AuthAuthenticator", "=== AUTHENTICATE CALLED ===")
+        Log.d("AuthAuthenticator", "Response code: ${response.code}")
+        Log.d("AuthAuthenticator", "URL: ${response.request.url}")
+
+        // 401 Unauthorized가 아니면 null 반환 (인증 처리 안 함)
+        if (response.code != 401) {
+            Log.d("AuthAuthenticator", "Response code is not 401 - skipping authentication")
+            return null
+        }
+
+        // 로그인/회원가입/토큰 관련 API는 제외 (무한 루프 방지)
+        val requestUrl = response.request.url.toString()
+        val isAuthRelatedApi = requestUrl.contains("/auth/") ||
+                requestUrl.contains("/login") ||
+                requestUrl.contains("/signup") ||
+                requestUrl.contains("/tokens/refresh")
+
+        if (isAuthRelatedApi) {
+            Log.d("AuthAuthenticator", "Auth-related API - skipping token refresh")
+            return null
+        }
+
+        // 이미 재시도한 요청인지 확인 (무한 루프 방지)
+        val priorAuth = responseCount(response)
+        if (priorAuth >= 3) {
+            Log.w("AuthAuthenticator", "Too many failed attempts - giving up")
+            performLogout()
+            return null
+        }
+
+        Log.w("AuthAuthenticator", "Received 401 - Attempting token refresh (attempt $priorAuth)")
+        Log.d("AuthAuthenticator", "=== ATTEMPTING TOKEN REFRESH ===")
+
+        val refreshResult = runBlocking {
+            Log.d("AuthAuthenticator", "Calling tokenRefreshRepository.refreshToken()")
+            tokenRefreshRepository.refreshToken()
+        }
+
+        return when (refreshResult) {
+            is RetrofitResult.Success -> {
+                Log.i("AuthAuthenticator", "✅ Token refresh SUCCESSFUL - Retrying original request")
+
+                // 새로운 토큰으로 원래 요청 재시도
+                val newBearer = accessTokenProvider.bearer()
+                newBearer?.let { token ->
+                    Log.d("AuthAuthenticator", "New token (first 20 chars): ${token.take(20)}...")
+                    Log.d("AuthAuthenticator", "Retrying original request with new token")
+
+                    // 원래 요청을 새로운 토큰으로 재생성
+                    response.request.newBuilder()
+                        .header("Authorization", token)
+                        .build()
+                } ?: run {
+                    Log.e("AuthAuthenticator", "❌ New token is null after successful refresh")
+                    performLogout()
+                    null
+                }
+            }
+            is RetrofitResult.Fail -> {
+                Log.e("AuthAuthenticator", "❌ Token refresh FAILED: ${refreshResult.message}")
+                Log.e("AuthAuthenticator", "Status code: ${refreshResult.statusCode}")
+
+                // 리프레시 토큰도 만료된 경우 로그아웃 처리
+                if (refreshResult.statusCode == 401 || refreshResult.statusCode == 403) {
+                    Log.w("AuthAuthenticator", "Refresh token expired - performing logout")
+                    performLogout()
+                }
+                null
+            }
+            is RetrofitResult.Error -> {
+                Log.e("AuthAuthenticator", "❌ Token refresh ERROR: ${refreshResult.exception.message}")
+                Log.e("AuthAuthenticator", "Exception type: ${refreshResult.exception.javaClass.simpleName}")
+
+                // 네트워크 오류가 아닌 경우 로그아웃 처리
+                val isNetworkError = refreshResult.exception.message?.contains("network", ignoreCase = true) ?: false
+                if (!isNetworkError) {
+                    Log.w("AuthAuthenticator", "Token refresh error - performing logout")
+                    performLogout()
+                }
+                null
+            }
+        }
+    }
+
+    /**
+     * 재시도 횟수 확인 (무한 루프 방지)
+     */
+    private fun responseCount(response: Response): Int {
+        var result = 1
+        var currentResponse: Response? = response
+        while (currentResponse?.priorResponse != null) {
+            result++
+            currentResponse = currentResponse.priorResponse
+        }
+        return result
+    }
+
+    private fun performLogout() {
+        try {
+            Log.d("AuthAuthenticator", "=== PERFORMING LOGOUT ===")
+
+            // 로컬 토큰 삭제
+            authTokenLocalStore.clearTokens()
+            Log.d("AuthAuthenticator", "✅ Local tokens cleared")
+
+            // 로그인 액티비티로 이동 (Application Context 사용)
+            val context = MyApplication.getApplicationContext()
+            if (context != null) {
+                val intent = Intent(context, LoginActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+                context.startActivity(intent)
+                Log.d("AuthAuthenticator", "✅ Redirected to login activity")
+            } else {
+                Log.e("AuthAuthenticator", "❌ Application context is null - cannot start login activity")
+            }
+
+        } catch (e: Exception) {
+            Log.e("AuthAuthenticator", "❌ Error during logout: ${e.message}", e)
+        }
+    }
+}
+

--- a/app/src/main/java/com/ssu/assu/di/ServiceModule.kt
+++ b/app/src/main/java/com/ssu/assu/di/ServiceModule.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RequiresApi
 import com.ssu.assu.BuildConfig
 import com.ssu.assu.data.dto.converter.LocalDateAdapter
 import com.ssu.assu.data.dto.converter.LocalDateTimeAdapter
+import com.ssu.assu.data.remote.AuthAuthenticator
 import com.ssu.assu.data.remote.AuthInterceptor
 import com.ssu.assu.data.remote.TokenRefreshInterceptor
 import com.ssu.assu.data.service.AuthService
@@ -75,9 +76,13 @@ object ServiceModule {
     }
 
     @Provides @Singleton @Auth
-    fun provideOkHttp(authInterceptor: AuthInterceptor): OkHttpClient =
+    fun provideOkHttp(
+        authInterceptor: AuthInterceptor,
+        authAuthenticator: AuthAuthenticator
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
+            .authenticator(authAuthenticator)
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY // 개발에서만
             })

--- a/app/src/main/java/com/ssu/assu/presentation/common/login/LoginActivity.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/common/login/LoginActivity.kt
@@ -137,9 +137,14 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
         }
         
         // 자동 로그인 체크 (Observer 설정 후에 호출, 한 번만 실행)
+        Log.d("LoginActivity", "=== initObserver - 자동 로그인 체크 준비 ===")
+        Log.d("LoginActivity", "isAutoLoginChecked 현재 값: $isAutoLoginChecked")
         if (!isAutoLoginChecked) {
+            Log.d("LoginActivity", "자동 로그인 체크 호출")
             checkAutoLogin()
             isAutoLoginChecked = true
+        } else {
+            Log.d("LoginActivity", "자동 로그인 이미 체크됨 - 건너뛰기")
         }
     }
 
@@ -173,20 +178,10 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
 
     private fun checkAutoLogin() {
-        // 이미 자동 로그인 체크가 완료되었거나 로그인 중이면 건너뛰기
-        if (isAutoLoginChecked) {
-            Log.d("LoginActivity", "자동 로그인 체크 이미 완료됨 - 건너뛰기")
-            return
-        }
-        
-        val loginModel = loginViewModel.checkAutoLogin()
-        if (loginModel != null) {
-            Log.d("LoginActivity", "자동 로그인 성공 - 메인 화면으로 이동")
-            isAutoLoginChecked = true
-            navigateToMainActivity(loginModel.userRole)
-        } else {
-            Log.d("LoginActivity", "자동 로그인 실패 - 로그인 화면 유지")
-        }
+        Log.d("LoginActivity", "=== 자동 로그인 체크 시작 ===")
+        // 토큰 리프레시를 포함한 자동 로그인 체크
+        // LoginState.Success가 발생하면 Observer에서 자동으로 메인 화면으로 이동
+        loginViewModel.checkAutoLoginWithRefresh()
     }
 
     private fun Int.dpToPx(context: Context): Int =

--- a/app/src/main/java/com/ssu/assu/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/ssu/assu/ui/auth/LoginViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ssu.assu.data.local.AuthTokenLocalStore
+import com.ssu.assu.data.repository.TokenRefreshRepository
 import com.ssu.assu.domain.model.auth.LoginModel
 import com.ssu.assu.domain.usecase.auth.CommonLoginUseCase
 import com.ssu.assu.domain.usecase.auth.StudentLoginUseCase
@@ -18,7 +19,8 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val studentLoginUseCase: StudentLoginUseCase,
     private val commonLoginUseCase: CommonLoginUseCase,
-    private val authTokenLocalStore: AuthTokenLocalStore
+    private val authTokenLocalStore: AuthTokenLocalStore,
+    private val tokenRefreshRepository: TokenRefreshRepository
 ) : ViewModel() {
     
     private val _loginState = MutableLiveData<LoginState>()
@@ -123,6 +125,74 @@ class LoginViewModel @Inject constructor(
             authTokenLocalStore.getLoginModel()
         } else {
             null
+        }
+    }
+    
+    /**
+     * 앱 시작 시 저장된 토큰으로 자동 로그인 시도
+     * 토큰이 만료되었으면 리프레시를 시도하고, 성공하면 LoginModel 반환
+     */
+    fun checkAutoLoginWithRefresh() {
+        viewModelScope.launch {
+            Log.d("LoginViewModel", "=== 자동 로그인 체크 시작 ===")
+            
+            if (!authTokenLocalStore.isLoggedIn()) {
+                Log.d("LoginViewModel", "저장된 로그인 정보 없음")
+                return@launch
+            }
+            
+            val accessToken = authTokenLocalStore.getAccessToken()
+            val refreshToken = authTokenLocalStore.getRefreshToken()
+            
+            if (accessToken == null || refreshToken == null) {
+                Log.w("LoginViewModel", "토큰 정보 불완전 - 자동 로그인 불가")
+                authTokenLocalStore.clearTokens()
+                return@launch
+            }
+            
+            Log.d("LoginViewModel", "저장된 토큰 확인 완료")
+            
+            // 토큰이 만료되었거나 곧 만료될 예정이면 리프레시 시도
+            val isExpiringSoon = authTokenLocalStore.isAccessTokenExpiringSoon()
+            val isExpired = authTokenLocalStore.isAccessTokenExpired()
+            
+            Log.d("LoginViewModel", "토큰 만료: $isExpired, 곧 만료: $isExpiringSoon")
+            
+            if (isExpired || isExpiringSoon) {
+                Log.i("LoginViewModel", "토큰 리프레시 시도...")
+                _loginState.value = LoginState.Loading
+                
+                when (val result = tokenRefreshRepository.refreshToken()) {
+                    is RetrofitResult.Success -> {
+                        Log.i("LoginViewModel", "✅ 토큰 리프레시 성공 - 자동 로그인")
+                        val loginModel = authTokenLocalStore.getLoginModel()
+                        if (loginModel != null) {
+                            _loginState.value = LoginState.Success(loginModel)
+                        } else {
+                            Log.e("LoginViewModel", "리프레시 후 LoginModel이 null")
+                        }
+                    }
+                    is RetrofitResult.Fail -> {
+                        Log.e("LoginViewModel", "❌ 토큰 리프레시 실패: ${result.message}")
+                        authTokenLocalStore.clearTokens()
+                        _loginState.value = LoginState.Idle
+                    }
+                    is RetrofitResult.Error -> {
+                        Log.e("LoginViewModel", "❌ 토큰 리프레시 오류: ${result.exception.message}")
+                        // 네트워크 오류는 토큰을 삭제하지 않음
+                        _loginState.value = LoginState.Idle
+                    }
+                }
+            } else {
+                // 토큰이 유효하면 바로 자동 로그인
+                Log.i("LoginViewModel", "✅ 토큰 유효 - 자동 로그인")
+                val loginModel = authTokenLocalStore.getLoginModel()
+                if (loginModel != null) {
+                    _loginState.value = LoginState.Success(loginModel)
+                } else {
+                    Log.e("LoginViewModel", "LoginModel이 null")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## #️⃣PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정

## 🪵반영 브랜치
ex) feat/login -> dev
close #138 

## 📝작업 내용
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 1. AuthAuthenticator 클래스 추가
- OkHttp3 `Authenticator` 인터페이스 구현
- 401 에러 발생 시 자동으로 토큰 리프레시 시도
- 토큰 갱신 후 원래 요청 자동 재시도
- 무한 루프 방지 (최대 3회 재시도)
- 리프레시 토큰 만료 시 자동 로그아웃 처리

### 2. AuthInterceptor 개선
- 401 처리 로직 제거 (Authenticator로 역할 분리)
- response 헤더에서 `Authorization` 값 자동 감지 및 저장
- 요청 헤더에 JWT 토큰 추가 기능 유지

### 3. 자동 로그인 로직 개선
- `LoginViewModel.checkAutoLoginWithRefresh()` 메서드 추가
- 앱 시작 시 토큰 만료 여부 확인
- 만료된 토큰 자동 리프레시 후 로그인
- 유효한 토큰은 즉시 자동 로그인

### 4. ServiceModule 업데이트
- `AuthAuthenticator`를 OkHttpClient에 등록
- 401 에러 발생 시 자동으로 Authenticator 호출

## 변경 사항

- AuthAuthenticator 클래스 추가: 401 에러 발생 시 자동 토큰 리프레시 및 재시도
- AuthInterceptor 개선: response 헤더에서 Authorization 토큰 자동 업데이트 기능 추가
- LoginViewModel에 checkAutoLoginWithRefresh() 메서드 추가: 앱 시작 시 토큰 만료 확인 및 자동 갱신
- LoginActivity 자동 로그인 로직 개선: 토큰 리프레시 포함한 자동 로그인 처리
- ServiceModule에 AuthAuthenticator 등록: OkHttpClient에 Authenticator 추가

Changes:
- AuthInterceptor에서 401 처리 로직 제거 (Authenticator로 이동)
- response 헤더에서 새로운 Access Token 자동 저장 기능 추가
- 앱 사용 중 토큰 만료 시 자동으로 토큰 갱신 후 API 재시도
- 앱 시작 시 토큰 만료 확인 및 필요시 자동 리프레시 후 로그인

## ✅테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
