### PR TITLE
[FEAT/#163] 1학기 운영용 앱리뷰 UI 및 API 연동

### DIFF
--- a/app/src/main/java/com/ssu/assu/MyApplication.kt
+++ b/app/src/main/java/com/ssu/assu/MyApplication.kt
@@ -6,9 +6,9 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.util.Log
-import com.ssu.assu.data.service.TokenManagementService
-import com.ssu.assu.data.service.PeriodicLoginPromptService
 import com.kakao.vectormap.KakaoMapSdk
+import com.ssu.assu.data.service.PeriodicLoginPromptService
+import com.ssu.assu.data.service.TokenManagementService
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -61,9 +61,9 @@ class MyApplication : Application() {
         super.onCreate()
         appContext = applicationContext
 
-//         카카오맵 초기화
-//        KakaoMapSdk.init(this, BuildConfig.KAKAO_MAP_KEY)
-//        Log.d("KakaoInit", "len=${BuildConfig.KAKAO_MAP_KEY.length}")
+        // 카카오맵 초기화
+        KakaoMapSdk.init(this, BuildConfig.KAKAO_MAP_KEY)
+        Log.d("KakaoInit", "len=${BuildConfig.KAKAO_MAP_KEY.length}")
 
         // 앱 시작 시 토큰 상태 확인 및 필요시 갱신
         applicationScope.launch {

--- a/app/src/main/java/com/ssu/assu/data/dto/review/request/AppReviewRequestDto.kt
+++ b/app/src/main/java/com/ssu/assu/data/dto/review/request/AppReviewRequestDto.kt
@@ -1,0 +1,9 @@
+package com.ssu.assu.data.dto.review.request
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AppReviewRequestDto(
+    val rate: Int,
+    val content: String
+)

--- a/app/src/main/java/com/ssu/assu/data/repository/review/ReviewRepository.kt
+++ b/app/src/main/java/com/ssu/assu/data/repository/review/ReviewRepository.kt
@@ -1,6 +1,7 @@
 package com.ssu.assu.data.repository.review
 
 import com.ssu.assu.data.dto.review.response.PageReviewList
+import com.ssu.assu.data.dto.review.request.AppReviewRequestDto
 import com.ssu.assu.data.dto.review.request.ReviewWriteRequestDto
 import com.ssu.assu.data.dto.review.response.DeleteReviewResponseDto
 import com.ssu.assu.data.dto.review.response.ReviewAverageResponseDto
@@ -40,4 +41,6 @@ interface ReviewRepository {
 
     suspend fun getMyStoreAverage() : RetrofitResult<ReviewAverageResponseDto>
     suspend fun getUserStoreAverage(storeId: Long) : RetrofitResult<ReviewAverageResponseDto>
+
+    suspend fun postAppReview(request: AppReviewRequestDto): RetrofitResult<Unit>
 }

--- a/app/src/main/java/com/ssu/assu/data/repositoryImpl/review/ReviewRepositoryImpl.kt
+++ b/app/src/main/java/com/ssu/assu/data/repositoryImpl/review/ReviewRepositoryImpl.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import com.ssu.assu.data.dto.review.response.PageReviewList
 import com.ssu.assu.data.dto.review.Review
+import com.ssu.assu.data.dto.review.request.AppReviewRequestDto
 import com.ssu.assu.data.dto.review.request.ReviewWriteRequestDto
 import com.ssu.assu.data.dto.review.response.DeleteReviewResponseDto
 import com.ssu.assu.data.dto.review.response.ReviewAverageResponseDto
@@ -14,6 +15,7 @@ import com.ssu.assu.data.repository.review.ReviewRepository
 import com.ssu.assu.data.service.review.ReviewService
 import com.ssu.assu.util.RetrofitResult
 import com.ssu.assu.util.apiHandler
+import com.ssu.assu.util.apiHandlerForUnit
 import com.google.gson.Gson
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -180,6 +182,17 @@ class ReviewRepositoryImpl @Inject constructor(
             RetrofitResult.Error(e)
         }
 
+    }
+
+    override suspend fun postAppReview(request: AppReviewRequestDto): RetrofitResult<Unit> {
+        return try {
+            apiHandlerForUnit(
+                execute = { api.postAppReview(request) },
+                mapper = { Unit }
+            )
+        } catch (e: Exception) {
+            RetrofitResult.Error(e)
+        }
     }
 
 }

--- a/app/src/main/java/com/ssu/assu/data/service/review/ReviewService.kt
+++ b/app/src/main/java/com/ssu/assu/data/service/review/ReviewService.kt
@@ -1,12 +1,14 @@
 package com.ssu.assu.data.service.review
 
 import com.ssu.assu.data.dto.BaseResponse
+import com.ssu.assu.data.dto.review.request.AppReviewRequestDto
 import com.ssu.assu.data.dto.review.response.DeleteReviewResponseDto
 import com.ssu.assu.data.dto.review.response.GetReviewResponseDto
 import com.ssu.assu.data.dto.review.response.ReviewAverageResponseDto
 import com.ssu.assu.data.dto.review.response.ReviewWriteResponseDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -60,4 +62,9 @@ interface ReviewService {
     suspend fun getUserStoreAverageScore(
         @Path("storeId") storeId: Long
     ): BaseResponse<ReviewAverageResponseDto>
+
+    @POST("/app-reviews")
+    suspend fun postAppReview(
+        @Body request: AppReviewRequestDto
+    ): BaseResponse<Any>
 }

--- a/app/src/main/java/com/ssu/assu/domain/usecase/review/PostAppReviewUseCase.kt
+++ b/app/src/main/java/com/ssu/assu/domain/usecase/review/PostAppReviewUseCase.kt
@@ -1,0 +1,13 @@
+package com.ssu.assu.domain.usecase.review
+
+import com.ssu.assu.data.dto.review.request.AppReviewRequestDto
+import com.ssu.assu.data.repository.review.ReviewRepository
+import com.ssu.assu.util.RetrofitResult
+import javax.inject.Inject
+
+class PostAppReviewUseCase @Inject constructor(
+    private val repo: ReviewRepository
+) {
+    suspend operator fun invoke(request: AppReviewRequestDto): RetrofitResult<Unit> =
+        repo.postAppReview(request)
+}

--- a/app/src/main/java/com/ssu/assu/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/base/BaseActivity.kt
@@ -1,14 +1,14 @@
 package com.ssu.assu.presentation.base
 
-import android.graphics.Color
 import android.os.Bundle
-import android.view.View
 import android.view.WindowManager
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import com.ssu.assu.R
 
 
 abstract class BaseActivity<V : ViewDataBinding>(@LayoutRes val layoutResource: Int) :
@@ -24,9 +24,8 @@ abstract class BaseActivity<V : ViewDataBinding>(@LayoutRes val layoutResource: 
         binding.lifecycleOwner = this
         setContentView(binding.root)
 
-        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
         setWindowFlag(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, false)
-        window.statusBarColor = Color.TRANSPARENT
+        window.statusBarColor = ContextCompat.getColor(this, R.color.assu_background)
         WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
 
         initObserver()

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/UserVerifyViewModel.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/UserVerifyViewModel.kt
@@ -8,15 +8,20 @@ import androidx.lifecycle.viewModelScope
 import com.ssu.assu.data.dto.certification.request.PersonalCertificationRequestDto
 import com.ssu.assu.data.dto.certification.request.TemporaryQrDataRequestDto
 import com.ssu.assu.data.dto.certification.request.UserSessionRequestDto
+import com.ssu.assu.data.dto.review.request.AppReviewRequestDto
 import com.ssu.assu.data.dto.store.PaperContent
 import com.ssu.assu.data.dto.usage.SaveUsageRequestDto
 import com.ssu.assu.domain.usecase.certification.GetSessionIdUseCase
 import com.ssu.assu.domain.usecase.certification.PostPersonalDataUseCase
 import com.ssu.assu.domain.usecase.certification.PostTemporaryQrDataUseCase
+import com.ssu.assu.domain.usecase.review.PostAppReviewUseCase
 import com.ssu.assu.domain.usecase.store.GetStorePartnershipUseCase
 import com.ssu.assu.domain.usecase.usage.SaveUsageUseCase
 import com.ssu.assu.util.RetrofitResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,7 +31,8 @@ class UserVerifyViewModel @Inject constructor(
     private val certificationUseCase: GetSessionIdUseCase,
     private val saveUsageUseCase: SaveUsageUseCase,
     private val personalCertifyUseCase: PostPersonalDataUseCase,
-    private val temporaryQrDataUseCase: PostTemporaryQrDataUseCase
+    private val temporaryQrDataUseCase: PostTemporaryQrDataUseCase,
+    private val postAppReviewUseCase: PostAppReviewUseCase
 ): ViewModel(){
 
     // 기본 정보
@@ -161,6 +167,30 @@ class UserVerifyViewModel @Inject constructor(
         viewModelScope.launch {
             temporaryQrDataUseCase(request)
         }
+    }
+
+    private val _appReviewSubmitResult = MutableStateFlow<RetrofitResult<Unit>?>(null)
+    val appReviewSubmitResult: StateFlow<RetrofitResult<Unit>?> = _appReviewSubmitResult.asStateFlow()
+
+    fun submitAppReview(rate: Int, content: String) {
+        viewModelScope.launch {
+            when (val result = postAppReviewUseCase(AppReviewRequestDto(rate = rate, content = content))) {
+                is RetrofitResult.Success -> {
+                    insertTemporaryQrData("REVIEW")
+                    _appReviewSubmitResult.value = result
+                }
+                is RetrofitResult.Error -> {
+                    _appReviewSubmitResult.value = result
+                }
+                is RetrofitResult.Fail -> {
+                    _appReviewSubmitResult.value = result
+                }
+            }
+        }
+    }
+
+    fun clearAppReviewResult() {
+        _appReviewSubmitResult.value = null
     }
 
     fun selectService(service: String) {

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/UserVerifyViewModel.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/UserVerifyViewModel.kt
@@ -19,9 +19,6 @@ import com.ssu.assu.domain.usecase.store.GetStorePartnershipUseCase
 import com.ssu.assu.domain.usecase.usage.SaveUsageUseCase
 import com.ssu.assu.util.RetrofitResult
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -169,21 +166,21 @@ class UserVerifyViewModel @Inject constructor(
         }
     }
 
-    private val _appReviewSubmitResult = MutableStateFlow<RetrofitResult<Unit>?>(null)
-    val appReviewSubmitResult: StateFlow<RetrofitResult<Unit>?> = _appReviewSubmitResult.asStateFlow()
+    private val _appReviewSubmitResult = MutableLiveData<RetrofitResult<Unit>?>()
+    val appReviewSubmitResult: LiveData<RetrofitResult<Unit>?> = _appReviewSubmitResult
 
     fun submitAppReview(rate: Int, content: String) {
         viewModelScope.launch {
             when (val result = postAppReviewUseCase(AppReviewRequestDto(rate = rate, content = content))) {
                 is RetrofitResult.Success -> {
                     insertTemporaryQrData("REVIEW")
-                    _appReviewSubmitResult.value = result
+                    _appReviewSubmitResult.postValue(result)
                 }
                 is RetrofitResult.Error -> {
-                    _appReviewSubmitResult.value = result
+                    _appReviewSubmitResult.postValue(result)
                 }
                 is RetrofitResult.Fail -> {
-                    _appReviewSubmitResult.value = result
+                    _appReviewSubmitResult.postValue(result)
                 }
             }
         }

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/AppReviewDialogFragment.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/AppReviewDialogFragment.kt
@@ -8,14 +8,16 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.Observer
 import com.ssu.assu.R
 import com.ssu.assu.databinding.DialogAppReviewBinding
 import com.ssu.assu.presentation.user.home.UserVerifyViewModel
 import com.ssu.assu.util.RetrofitResult
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
+
+fun interface OnAppReviewSuccessListener {
+    fun onAppReviewSuccess()
+}
 
 @AndroidEntryPoint
 class AppReviewDialogFragment : DialogFragment() {
@@ -70,28 +72,29 @@ class AppReviewDialogFragment : DialogFragment() {
             viewModel.submitAppReview(selectedRate, content)
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.appReviewSubmitResult.collectLatest { result ->
-                when (result) {
-                    is RetrofitResult.Success -> dismiss()
-                    is RetrofitResult.Error -> {
-                        Toast.makeText(
-                            requireContext(),
-                            "리뷰 작성에 실패했습니다. ${result.exception.message}",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                    is RetrofitResult.Fail -> {
-                        Toast.makeText(
-                            requireContext(),
-                            "리뷰 작성에 실패했습니다. ${result.message}",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                    null -> { }
+        viewModel.appReviewSubmitResult.observe(viewLifecycleOwner, Observer { result ->
+            when (result) {
+                is RetrofitResult.Success -> {
+                    dismiss()
+                    (targetFragment as? OnAppReviewSuccessListener)?.onAppReviewSuccess()
                 }
+                is RetrofitResult.Error -> {
+                    Toast.makeText(
+                        requireContext(),
+                        "리뷰 작성에 실패했습니다. ${result.exception.message}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                is RetrofitResult.Fail -> {
+                    Toast.makeText(
+                        requireContext(),
+                        "리뷰 작성에 실패했습니다. ${result.message}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                null -> { }
             }
-        }
+        })
     }
 
     private fun updateStarAppearance(rating: Int) {

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/AppReviewDialogFragment.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/AppReviewDialogFragment.kt
@@ -1,0 +1,117 @@
+package com.ssu.assu.presentation.user.home.temporary
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.ssu.assu.R
+import com.ssu.assu.databinding.DialogAppReviewBinding
+import com.ssu.assu.presentation.user.home.UserVerifyViewModel
+import com.ssu.assu.util.RetrofitResult
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class AppReviewDialogFragment : DialogFragment() {
+
+    private val viewModel: UserVerifyViewModel by activityViewModels()
+    private var _binding: DialogAppReviewBinding? = null
+    private val binding get() = _binding!!
+
+    private var selectedRate: Int = 0
+    private lateinit var starImageViews: List<ImageView>
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogAppReviewBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
+
+        starImageViews = listOf(
+            binding.ivAppReviewStar1,
+            binding.ivAppReviewStar2,
+            binding.ivAppReviewStar3,
+            binding.ivAppReviewStar4,
+            binding.ivAppReviewStar5
+        )
+
+        binding.btnAppReviewClose.setOnClickListener { dismiss() }
+
+        starImageViews.forEachIndexed { index, imageView ->
+            imageView.setOnClickListener {
+                selectedRate = index + 1
+                updateStarAppearance(selectedRate)
+            }
+        }
+
+        binding.btnAppReviewSubmit.setOnClickListener {
+            val content = binding.etAppReviewContent.text?.toString()?.trim().orEmpty()
+            if (selectedRate !in 1..5) {
+                Toast.makeText(requireContext(), "별점을 선택해주세요.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            if (content.isEmpty()) {
+                Toast.makeText(requireContext(), "내용을 입력해주세요.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            viewModel.submitAppReview(selectedRate, content)
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.appReviewSubmitResult.collectLatest { result ->
+                when (result) {
+                    is RetrofitResult.Success -> dismiss()
+                    is RetrofitResult.Error -> {
+                        Toast.makeText(
+                            requireContext(),
+                            "리뷰 작성에 실패했습니다. ${result.exception.message}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    is RetrofitResult.Fail -> {
+                        Toast.makeText(
+                            requireContext(),
+                            "리뷰 작성에 실패했습니다. ${result.message}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    null -> { }
+                }
+            }
+        }
+    }
+
+    private fun updateStarAppearance(rating: Int) {
+        starImageViews.forEachIndexed { index, imageView ->
+            val drawableRes = if (index < rating) R.drawable.ic_activated_star
+            else R.drawable.ic_deactivated_star
+            imageView.setImageResource(drawableRes)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val displayMetrics = resources.displayMetrics
+        val width = displayMetrics.widthPixels
+        val dialogWidth = (width * 0.8396f).toInt()
+        dialog?.window?.setLayout(dialogWidth, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/UserEventSelectFragment.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/UserEventSelectFragment.kt
@@ -2,21 +2,16 @@ package com.ssu.assu.presentation.user.home.temporary
 
 import android.app.Activity
 import android.content.Intent
-import android.util.Log
 import android.view.View
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.viewModelScope
 import com.ssu.assu.R
-import com.ssu.assu.data.dto.certification.request.TemporaryQrDataRequestDto
 import com.ssu.assu.databinding.FragmentUserEventSelectBinding
 import com.ssu.assu.presentation.base.BaseFragment
 import com.ssu.assu.presentation.user.dashboard.UserServiceSuggestActivity
 import com.ssu.assu.presentation.user.home.UserVerifyViewModel
-import kotlinx.coroutines.launch
-import kotlin.getValue
 
 class UserEventSelectFragment : BaseFragment<FragmentUserEventSelectBinding>(R.layout.fragment_user_event_select) {
 private val startActivity = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -114,8 +109,8 @@ private val startActivity = registerForActivityResult(ActivityResultContracts.St
         }
     }
 
-    private fun toAssuReviewWrite(){
-        viewModel.insertTemporaryQrData("REVIEW")
+    private fun toAssuReviewWrite() {
+        AppReviewDialogFragment().show(parentFragmentManager, "AppReviewDialog")
     }
 
     private fun toSuggestPartnership(){

--- a/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/UserEventSelectFragment.kt
+++ b/app/src/main/java/com/ssu/assu/presentation/user/home/temporary/UserEventSelectFragment.kt
@@ -13,7 +13,8 @@ import com.ssu.assu.presentation.base.BaseFragment
 import com.ssu.assu.presentation.user.dashboard.UserServiceSuggestActivity
 import com.ssu.assu.presentation.user.home.UserVerifyViewModel
 
-class UserEventSelectFragment : BaseFragment<FragmentUserEventSelectBinding>(R.layout.fragment_user_event_select) {
+class UserEventSelectFragment : BaseFragment<FragmentUserEventSelectBinding>(R.layout.fragment_user_event_select),
+    OnAppReviewSuccessListener {
 private val startActivity = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
 
     if (result.resultCode == Activity.RESULT_OK) {
@@ -26,8 +27,14 @@ private val startActivity = registerForActivityResult(ActivityResultContracts.St
     private var selectedIndex: Int? = null
     private val viewModel: UserVerifyViewModel by activityViewModels()
     private lateinit var eventButtons: List<View>
-    override fun initObserver() {
+    override fun initObserver() {}
 
+    override fun onAppReviewSuccess() {
+        viewModel.clearAppReviewResult()
+        requireActivity().supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container_view, UserTemporaryCompleteFragment())
+            .addToBackStack(null)
+            .commitAllowingStateLoss()
     }
 
     override fun initView() {
@@ -110,7 +117,8 @@ private val startActivity = registerForActivityResult(ActivityResultContracts.St
     }
 
     private fun toAssuReviewWrite() {
-        AppReviewDialogFragment().show(parentFragmentManager, "AppReviewDialog")
+        AppReviewDialogFragment().apply { setTargetFragment(this@UserEventSelectFragment, 0) }
+            .show(parentFragmentManager, "AppReviewDialog")
     }
 
     private fun toSuggestPartnership(){

--- a/app/src/main/res/layout/activity_user_my_partnership_list.xml
+++ b/app/src/main/res/layout/activity_user_my_partnership_list.xml
@@ -7,6 +7,7 @@
         android:id="@+id/main"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/assu_background"
         tools:context=".presentation.user.home.UserMyPartnershipListActivity">
 
         <View

--- a/app/src/main/res/layout/dialog_app_review.xml
+++ b/app/src/main/res/layout/dialog_app_review.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="15dp"
+    android:layout_marginEnd="15dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="20dp"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:background="@drawable/bg_review_delete_dialog">
+
+    <TextView
+        android:id="@+id/tv_app_review_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="후기를 작성해주세요!"
+        android:includeFontPadding="false"
+        android:fontFamily="@font/pretendard_semibold"
+        android:textColor="@color/assu_font_main"
+        android:textSize="20sp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_app_review_close" />
+
+    <ImageView
+        android:id="@+id/btn_app_review_close"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_cross"
+        android:padding="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_app_review_title"
+        app:layout_constraintBottom_toBottomOf="@id/tv_app_review_title" />
+
+    <TextView
+        android:id="@+id/tv_app_review_subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="소중한 후기는 ASSU의 힘이 됩니다."
+        android:textColor="@color/assu_font_sub"
+        android:textSize="13sp"
+        android:fontFamily="@font/pretendard_regular"
+        app:layout_constraintTop_toBottomOf="@id/tv_app_review_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/layout_app_review_stars"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="25dp"
+        android:orientation="horizontal"
+        android:gravity="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_app_review_subtitle">
+
+        <ImageView
+            android:id="@+id/iv_app_review_star1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_deactivated_star" />
+        <ImageView
+            android:id="@+id/iv_app_review_star2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_deactivated_star" />
+        <ImageView
+            android:id="@+id/iv_app_review_star3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_deactivated_star" />
+        <ImageView
+            android:id="@+id/iv_app_review_star4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_deactivated_star" />
+        <ImageView
+            android:id="@+id/iv_app_review_star5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:src="@drawable/ic_deactivated_star" />
+    </LinearLayout>
+
+    <EditText
+        android:id="@+id/et_app_review_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="25dp"
+        android:minHeight="100dp"
+        android:gravity="top|start"
+        android:padding="12dp"
+        android:background="@drawable/bg_empty_line_box"
+        android:hint="내용을 입력해주세요"
+        android:textColorHint="@color/assu_font_sub"
+        android:textColor="@color/assu_font_main"
+        android:textSize="14sp"
+        android:fontFamily="@font/pretendard_regular"
+        android:inputType="textMultiLine|textCapSentences"
+        app:layout_constraintTop_toBottomOf="@id/layout_app_review_stars"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/btn_app_review_submit"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="25dp"
+        android:background="@drawable/btn_basic_selected"
+        android:text="작성완료"
+        android:gravity="center"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:fontFamily="@font/pretendard_semibold"
+        app:layout_constraintTop_toBottomOf="@id/et_app_review_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,5 +3,6 @@
     <style name="Base.Theme.ASSU_FE_app" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="android:statusBarColor">@color/assu_background</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Base.Theme.ASSU_FE_app" parent="Theme.Material3.DayNight.NoActionBar" />
+    <style name="Base.Theme.ASSU_FE_app" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@color/assu_background</item>
+    </style>
 
     <style name="Theme.ASSU_FE_app" parent="Base.Theme.ASSU_FE_app">
         <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="31">@drawable/assu_splash_logo</item>


### PR DESCRIPTION
## #️⃣PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪵반영 브랜치
ex) feat/login -> dev

## 📝작업 내용
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 다이얼로그 UI 개발
- 앱 리뷰 작성 모달 추가
  - UserEventSelectFragment에서 "앱 리뷰 작성" 선택 후 완료 시, 기존처럼 바로 insertTemporaryQrData 호출하지 않고 앱 리뷰 다이얼로그를 띄우도록 변경
- 앱 리뷰 API 연동
  - 작성완료 버튼 클릭 시 POST /app-reviews (rate, content) 호출 후, 성공 시 UserVerifyViewModel.insertTemporaryQrData("REVIEW") 호출로 임시 QR 데이터를 넣고, 다이얼로그를 닫은 뒤 UserTemporaryCompleteFragment로 이동하도록 구현

## ✅테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
<img width="1080" height="2210" alt="image" src="https://github.com/user-attachments/assets/df6f4cb2-f4c1-457c-8264-a914c35fd604" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
